### PR TITLE
Remove package scope while in early development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arigato/common",
+  "name": "common",
   "version": "0.0.1",
   "description": "Common node resources",
   "main": "index.js",


### PR DESCRIPTION
We'll switch back to private packages when we're more stable.
