### PR TITLE
Introduce cpath.compare() for specificity compare

### DIFF
--- a/cpath/compare.js
+++ b/cpath/compare.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Implements a definitionsExp compareFunction for use in Array#sort. For use in
+ * specificity checking.
+ *
+ * definitionsExp specificity is important in deciding which values we pull from the
+ * hierarchy and provide to the user.
+ *
+ * Token Specificity Rules:
+ *
+ *  SLUG = 1
+ *  SLUG_WILDCARD = 2
+ *  OR_EXP = 3
+ *  WILDCARD = 4
+ *
+ * Token Type[A] > Token Type[B] Return 1
+ * Token Type[A] === Token Type[B] Return 0
+ * Token Type[A] < Token Type[B] Return -1
+ *
+ * If the token types match, we continue iterating. Otherwise, we return the
+ * value immediately.
+ *
+ * @param {String} a
+ * @param {String} b
+ * @return {Number}
+ */
+
+var cpath = require('./index');
+var definitions = require('./definitions');
+
+var PART_TYPE_REGEX_MAP = {
+  'SLUG': definitions.SLUG_REGEX,
+  'SLUG_WILDCARD': definitions.SLUG_WILDCARD_REGEX,
+  'OR': definitions.OR_EXP_REGEX,
+  'WILDCARD': definitions.WILDCARD_REGEX
+};
+
+var PART_TYPES = Object.keys(PART_TYPE_REGEX_MAP);
+
+var PART_TYPE_SCORE = {
+  'SLUG': 4,
+  'SLUG_WILDCARD': 3,
+  'OR': 2,
+  'WILDCARD': 1
+};
+
+module.exports = function (a, b) {
+  a = (a instanceof cpath.CPathExp) ? a : new cpath.CPathExp(a);
+  b = (b instanceof cpath.CPathExp) ? b : new cpath.CPathExp(b);
+
+  var typeA;
+  var typeB;
+  var scoreA;
+  var scoreB;
+
+  for (var i = 0; i < a.parts.length; ++i) {
+    typeA = getPartType(a.parts[i]);
+    typeB = getPartType(b.parts[i]);
+
+    scoreA = PART_TYPE_SCORE[typeA];
+    scoreB = PART_TYPE_SCORE[typeB];
+
+    if (!scoreA || !scoreB) {
+      throw new Error('Unknown score type: ' + typeA + ' or ' + typeB);
+    }
+
+    if (scoreA === scoreB) {
+      continue;
+    }
+
+    if (scoreA > scoreB) {
+      return 1;
+    }
+
+    if (scoreA < scoreB) {
+      return -1;
+    } 
+  }
+
+  return 0;
+};
+
+function getPartType (part) {
+  var type;
+  for (var i = 0; i < PART_TYPES.length; ++i) {
+    type = PART_TYPES[i];
+    if (PART_TYPE_REGEX_MAP[type].test(part)) {
+      return type;
+    }
+  }
+
+  throw new Error('Part did not match a PART_TYPE: ' + part);
+}

--- a/cpath/definitions.js
+++ b/cpath/definitions.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var definitions = module.exports;
+
+var SLUG = '[a-z0-9][a-z0-9\\-\\_]{0,63}';
+var WILDCARD = '[\\*]';
+
+// We only support `text*` and `*` for wildcarding in a slug
+var SLUG_WILDCARD = SLUG + WILDCARD + '?';
+var SLUG_OR_WILDCARD = '(?:' + SLUG_WILDCARD + '|' + WILDCARD + ')';
+
+var OR_EXP = '\\[(?:(' + SLUG_WILDCARD + ')\\|)*(' + SLUG_WILDCARD + ')\\]';
+var SLUG_WILDCARD_OR_EXP = '(?:' + SLUG_OR_WILDCARD + '|' + OR_EXP + ')';
+var CPATHEXP_REGEX_STR = '^/' +
+                        SLUG + '/' + // org
+                        SLUG + '/' + // project
+                        SLUG_WILDCARD_OR_EXP + '/' + // environment
+                        SLUG_WILDCARD_OR_EXP + '/' + // service
+                        SLUG_WILDCARD_OR_EXP + '/' + // identity
+
+                        // XXX: Is an instance always a number?
+                        SLUG_OR_WILDCARD + // instance
+                      '$'; // no trailing slash
+
+var CPATH_REGEX_STR = '^/'+
+                        SLUG + '/' + // org
+                        SLUG + '/' + // project
+                        SLUG + '/' + // environment
+                        SLUG + '/' + // service
+                        SLUG + '/' + // identity
+
+                        // XXX: Is an instance always a number?
+                        SLUG + // instance
+                      '$'; // no trailing slash
+
+var WILDCARD_REGEX = definitions.WILDCARD_REGEX =
+  new RegExp('^' + WILDCARD + '$');
+var SLUG_REGEX = definitions.SLUG_REGEX =
+  new RegExp('^' + SLUG + '$');
+var SLUG_WILDCARD_REGEX = definitions.SLUG_WILDCARD_REGEX = 
+  new RegExp('^' + SLUG_WILDCARD + '$');
+var OR_EXP_REGEX = definitions.OR_EXP_REGEX =
+  new RegExp('^' + OR_EXP + '$');
+var SLUG_OR_WILDCARD_REGEX = definitions.SLUG_OR_WILDCARD_REGEX = 
+  new RegExp('^' + SLUG_OR_WILDCARD + '$');
+var CPATHEXP_REGEX = definitions.CPATHEXP_REGEX =
+  new RegExp(CPATHEXP_REGEX_STR);
+var CPATH_REGEX = definitions.CPATH_REGEX =
+  new RegExp(CPATH_REGEX_STR);
+

--- a/cpath/index.js
+++ b/cpath/index.js
@@ -49,43 +49,8 @@ var util = require('util');
 
 var normalize = require('./normalize');
 var regex = require('./regex');
-
-var SLUG = '[a-z0-9][a-z0-9\\-\\_]{0,63}';
-var WILDCARD = '[\\*]';
-
-// We only support `text*` and `*` for wildcarding in a slug
-var SLUG_WILDCARD = SLUG + WILDCARD + '?';
-var SLUG_OR_WILDCARD = '(?:' + SLUG_WILDCARD + '|' + WILDCARD + ')';
-
-var OR_EXP = '\\[(?:(' + SLUG_WILDCARD + ')\\|)*(' + SLUG_WILDCARD + ')\\]';
-var SLUG_WILDCARD_OR_EXP = '(?:' + SLUG_OR_WILDCARD + '|' + OR_EXP + ')';
-var CPATHEXP_REGEX_STR = '^/' +
-                        SLUG + '/' + // org
-                        SLUG + '/' + // project
-                        SLUG_WILDCARD_OR_EXP + '/' + // environment
-                        SLUG_WILDCARD_OR_EXP + '/' + // service
-                        SLUG_WILDCARD_OR_EXP + '/' + // identity
-
-                        // XXX: Is an instance always a number?
-                        SLUG_OR_WILDCARD + // instance
-                      '$'; // no trailing slash
-
-var CPATH_REGEX_STR = '^/'+
-                        SLUG + '/' + // org
-                        SLUG + '/' + // project
-                        SLUG + '/' + // environment
-                        SLUG + '/' + // service
-                        SLUG + '/' + // identity
-
-                        // XXX: Is an instance always a number?
-                        SLUG + // instance
-                      '$'; // no trailing slash
-
-var OR_EXP_REGEX = cpath.OR_EXP_REGEX = new RegExp('^' + OR_EXP + '$');
-var SLUG_OR_WILDCARD_REGEX = cpath.SLUG_OR_WILDCARD_REGEX = new RegExp(
-  '^' + SLUG_OR_WILDCARD + '$');
-var CPATHEXP_REGEX = cpath.CPATHEXP_REGEX = new RegExp(CPATHEXP_REGEX_STR);
-var CPATH_REGEX = cpath.CPATH_REGEX = new RegExp(CPATH_REGEX_STR);
+var compare = require('./compare');
+var definitions = require('./definitions')
 
 cpath.parseExp = function (str) {
   return new CPathExp(str);
@@ -96,12 +61,14 @@ cpath.parse = function (str) {
 };
 
 cpath.validateExp = function (str) {
-  return CPATHEXP_REGEX.test(str);
+  return definitions.CPATHEXP_REGEX.test(str);
 };
 
 cpath.validate = function (str) {
-  return CPATH_REGEX.test(str);
+  return definitions.CPATH_REGEX.test(str);
 };
+
+cpath.compare = compare;
 
 cpath.normalizeExp = function (target) {
   if (!Array.isArray(target) && !cpath.validateExp(target)) {
@@ -131,6 +98,7 @@ function CPathExp (str) {
   parts = normalize.path(parts);
 
   this.regex = regex.builder(parts);
+  this.parts = parts;
 
   // XXX Think about defining properties on the object and parsing as they
   // are set to catch bugs further upstream then when toString is called.

--- a/cpath/normalize.js
+++ b/cpath/normalize.js
@@ -10,7 +10,7 @@
 
 var normalize = exports;
 
-var cpath = require('./index');
+var definitions = require('./definitions');
 
 function OR_PART (part) {
   var content = part.slice(1,part.length - 1); // Remove start and end [ ]
@@ -26,7 +26,7 @@ normalize.path = function (parts) {
   for (var i = 0; i < parts.length; ++i) {
     part = parts[i];
 
-    if (cpath.OR_EXP_REGEX.test(part)) {
+    if (definitions.OR_EXP_REGEX.test(part)) {
       output.push(OR_PART(part));
       continue;
     }

--- a/cpath/regex.js
+++ b/cpath/regex.js
@@ -1,14 +1,14 @@
 /**
- * CPathExp Regular Expression Builder
+ * definitionsExp Regular Expression Builder
  *
- * Given an array of CPathExp components this module returns a Regular
- * Expression object for matching against CPath strings.
+ * Given an array of definitionsExp components this module returns a Regular
+ * Expression object for matching against definitions strings.
  */
 'use strict';
 
 var regex = exports;
 
-var cpath = require('./index');
+var definitions = require('./definitions');
 
 function SLUG_OR_WILDCARD_PART (part) {
   var star = part.indexOf('*');
@@ -36,12 +36,12 @@ regex.builder = function (parts) {
   var output = [];
   for (var i = 0; i < parts.length; ++i) {
     part = parts[i];
-    if (cpath.OR_EXP_REGEX.test(part)) {
+    if (definitions.OR_EXP_REGEX.test(part)) {
       output.push(OR_PART(part));
       continue;
     }
 
-    if (cpath.SLUG_OR_WILDCARD_REGEX.test(part)) {
+    if (definitions.SLUG_OR_WILDCARD_REGEX.test(part)) {
       output.push(SLUG_OR_WILDCARD_PART(part));
       continue;
     }

--- a/tests/cpath.js
+++ b/tests/cpath.js
@@ -191,6 +191,29 @@ describe('cpath', function () {
     });
   });
 
+  describe('.compare', function () {
+    it('returns 0 if exact same', function () {
+      assert.strictEqual(cpath.compare(
+        '/org/proj/env/service/identity/instance',
+        '/org/proj/env/service/identity/instance'
+      ), 0);
+    });
+    
+    it('returns 1 if A is greater than B', function () {
+      assert.strictEqual(cpath.compare(
+        '/org/proj/env/service/identity/instance',
+        '/org/proj/*/service/identity/instance'
+      ), 1);
+    });
+
+    it('returns -1 if B is greater than B', function () {
+      assert.strictEqual(cpath.compare(
+        '/org/proj/dev-*/service/identity/instance',
+        '/org/proj/dev-username/service/identity/instance'
+      ), -1);
+    });
+  });
+
   describe('CPathExp', function() {
     describe('#compare', function() {
       it('matches directly', function() {


### PR DESCRIPTION
cpath.compare now returns a -1, 0, or 1 depending on whether A is more
specific than B.

This function is used for deduplicating credential values when they are
collapsed into a single name space by comparing path specificity.

Related arigatomachine/cli#350
