### PR TITLE
All object type notation checking is toLowerCase()

### DIFF
--- a/tests/util.js
+++ b/tests/util.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var crypto = require('crypto');
 
+var _ =require('lodash');
 var sinon = require('sinon');
 var base64url = require('base64url');
 var bufferEqual = require('buffer-equal');
@@ -23,7 +24,8 @@ describe('utils', function() {
       var id = utils.id('user');
       var buf = base64url.toBuffer(id);
 
-      assert.strictEqual(buf.slice(1,2).toString('hex'), objects.user.value);
+      assert.strictEqual(buf.slice(1,2).toString('hex'),
+                         objects.defn.user.value);
       assert.strictEqual(buf.slice(0,1).toString('hex'), '01');
       assert.strictEqual(buf.length, 18);
     });
@@ -35,7 +37,7 @@ describe('utils', function() {
 
       assert.strictEqual(buf.slice(0,1).toString('hex'), '01');
       assert.strictEqual(buf.slice(1,2).toString('hex'),
-                         objects.public_key.value);
+                         objects.defn.public_key.value);
 
       assert.ok(bufferEqual(hash, buf.slice(2)));
       assert.strictEqual(buf.length, 18);
@@ -90,7 +92,7 @@ describe('utils', function() {
   });
 
   describe('#type', function() {
-    it('returns the type', function() {
+    it('returns the type -- id is string', function() {
       var spy = sinon.spy(utils, 'validate');
       var id = utils.id('user');
 
@@ -98,6 +100,25 @@ describe('utils', function() {
 
       assert.strictEqual(type, 'user');
       sinon.assert.calledOnce(spy);
+    });
+
+    it('returns the type -- id is buffer', function () {
+      var buf = base64url.toBuffer(utils.id('user'));
+      assert.strictEqual(utils.type(buf), 'user');
+    });
+
+    it('matches uppercase type to lowercase -- id is buffer', function () {
+      var buf = crypto.randomBytes(18);
+      buf.write(utils.ID_VERSION_HEX, 0, 1, 'hex');
+      buf.write('0C', 1, 1, 'hex');
+
+      assert.strictEqual(utils.type(buf), 'verification_code');
+    });
+
+    it('no types have uppercase lettering', function () {
+      _.each(objects.defn, function (defn, name) {
+        assert.ok(!/[A-Z]/.test(defn.value), name + ' has uppercase value');
+      });
     });
   });
 });

--- a/types/objects.js
+++ b/types/objects.js
@@ -1,12 +1,14 @@
 'use strict';
 var _ = require('lodash');
 
+var objects = exports;
+
 /**
  * Mutable signifies whether or not the `id` field is a hash of the underlying
  * object. If it's set to false then it is immutable, otherwise, it's id is
  * generated using random data.
  */
-var objects = {
+var defn = objects.defn = {
   user: {
     mutable: true,
     value: '01' // Value represented in hex
@@ -53,19 +55,19 @@ var objects = {
   },
   verification_code: {
     mutable: true,
-    value: '0C'
+    value: '0c'
   },
   org: {
     mutable: true,
-    value: '0D'
+    value: '0d'
   },
   membership: {
     mutable: true,
-    value: '0E'
+    value: '0e'
   },
   team: {
     mutable: true,
-    value: '0F'
+    value: '0f'
   },
   token: {
     mutable: true,
@@ -77,13 +79,17 @@ objects.name = function(b) {
   b = ''+b; // coerce to string
   b = b.toLowerCase(); // must always be lowercase
 
-  return _.findKey(objects, function (val) {
+  return _.findKey(defn, function (val) {
     return val.value === b;
   });
 };
 
 objects.value = function(name) {
-  return objects[name].value;
+  if (!defn[name]) {
+    throw new TypeError('Unknown object type: ' + name);
+  }
+
+  return defn[name].value.toLowerCase();
 };
 
 module.exports = objects;

--- a/utils/index.js
+++ b/utils/index.js
@@ -38,17 +38,18 @@ var ID_VERSION_HEX = utils.ID_VERSION_HEX = '01';
  * @returns {String}
  */
 utils.id = function(type, payload) {
-  if (!objects[type]) {
+  var defn = objects.defn[type];
+  if (!defn) {
     throw new Error('unknown object type: ' + type);
   }
   if (payload &&  (!Buffer.isBuffer(payload) ||
                    payload.length !== PAYLOAD_BYTE_SIZE)) {
     throw new Error('Payload must be a buffer of 16 bytes');
   }
-  if (payload && objects[type].mutable) {
+  if (payload && defn.mutable) {
     throw new Error('Mutable objects do not accept payloads');
   }
-  if (!payload && !objects[type].mutable) {
+  if (!payload && !defn.mutable) {
     throw new Error(
       'A payload must be provided for an immutable object');
   }
@@ -87,7 +88,7 @@ utils.validate = function (id) {
   }
 
   if (!objects.name(hex.slice(2,4))) {
-    throw new Error('Unknown object id: '+hex);
+    throw new Error('Unknown object id: '+ hex.slice(2,4));
   }
 
   return id;


### PR DESCRIPTION
Currently, there is a bug where if an id type value contained an
uppercase letter it would never validate using `utils#validate` or
`utils#type` as there wouldn't be a direct match.

This pull request fixes this bug and adds several tests to prevent this
developer error from occurring in the future.

Related arigatomachine/cli#246
