### PR TITLE
Replace base64url encoded object ids with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,17 @@
   },
   "homepage": "https://github.com/arigatomachine/common#readme",
   "dependencies": {
+    "base32": "0.0.6",
     "base64url": "1.0.6",
     "buffer-equal": "1.0.0",
+    "cbwrap": "1.1.0",
     "es6-promise": "3.2.1",
     "lodash": "4.11.1",
     "recursive-readdir-sync": "1.0.6",
+    "triplesec": "3.0.25",
     "tv4": "1.2.7",
     "tv4-formats": "1.0.2",
-    "validator": "5.2.0",
-    "triplesec": "3.0.25",
-    "cbwrap": "1.1.0"
+    "validator": "5.2.0"
   },
   "devDependencies": {
     "gulp": "3.9.1",

--- a/tests/util.js
+++ b/tests/util.js
@@ -5,7 +5,7 @@ var crypto = require('crypto');
 
 var _ =require('lodash');
 var sinon = require('sinon');
-var base64url = require('base64url');
+var base32 = require('base32');
 var bufferEqual = require('buffer-equal');
 
 var utils = require('../utils');
@@ -22,7 +22,7 @@ describe('utils', function() {
 
     it('constructs a user id', function() {
       var id = utils.id('user');
-      var buf = base64url.toBuffer(id);
+      var buf = new Buffer(base32.decode(id), 'binary');
 
       assert.strictEqual(buf.slice(1,2).toString('hex'),
                          objects.defn.user.value);
@@ -33,7 +33,7 @@ describe('utils', function() {
     it('constructs a public_key id', function() {
       var hash = crypto.randomBytes(16);
       var id = utils.id('public_key', hash);
-      var buf = base64url.toBuffer(id);
+      var buf = new Buffer(base32.decode(id), 'binary');
 
       assert.strictEqual(buf.slice(0,1).toString('hex'), '01');
       assert.strictEqual(buf.slice(1,2).toString('hex'),
@@ -87,7 +87,7 @@ describe('utils', function() {
       var id = utils.id('user');
       var buf = utils.validate(id);
 
-      assert.ok(bufferEqual(buf, base64url.toBuffer(id)));
+      assert.ok(bufferEqual(buf, new Buffer(base32.decode(id), 'binary')));
     });
   });
 
@@ -103,7 +103,7 @@ describe('utils', function() {
     });
 
     it('returns the type -- id is buffer', function () {
-      var buf = base64url.toBuffer(utils.id('user'));
+      var buf = new Buffer(base32.decode(utils.id('user')), 'binary');
       assert.strictEqual(utils.type(buf), 'user');
     });
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,6 +1,6 @@
 /**
  * All objects inside Arigato are represented by an 18 byte identifier. This
- * identifier is represented in base64url for passing in a non-binary format.
+ * identifier is represented in base32 for passing in a non-binary format.
  *
  * Schema:
  *
@@ -21,7 +21,7 @@
 var utils = exports;
 
 var crypto = require('crypto');
-var base64url = require('base64url');
+var base32 = require('base32');
 
 var objects = require('../types/objects');
 
@@ -64,7 +64,7 @@ utils.id = function(type, payload) {
   payload = payload || crypto.randomBytes(PAYLOAD_BYTE_SIZE);
 
   var id = Buffer.concat([buf, payload]);
-  return base64url.encode(id);
+  return base32.encode(id);
 };
 
 /**
@@ -76,7 +76,7 @@ utils.id = function(type, payload) {
  * @returns Buffer
  */
 utils.validate = function (id) {
-  id = (!Buffer.isBuffer(id)) ? base64url.toBuffer(id) : id;
+  id = (!Buffer.isBuffer(id)) ? new Buffer(base32.decode(id), 'binary') : id;
 
   if (id.length !== ID_BYTE_SIZE) {
     throw new Error('An object id must be '+ID_BYTE_SIZE+' bytes');


### PR DESCRIPTION
At the expense of a few more bytes, we get something that is unambiguous to
the human eye.

related: arigatomachine/cli#413

This will require changes to cli and registry, too.
