### PR TITLE
Represent algos as strings instead of hex values

### DIFF
--- a/crypto/user.js
+++ b/crypto/user.js
@@ -34,7 +34,7 @@ user.encryptPasswordObject = function (password) {
     .then(function (passwordSalt) {
       data.password = {
         salt: base64url.encode(passwordSalt),
-        alg: algos.value('scrypt') // 0x23
+        alg: algos.value('scrypt')
       };
 
       // Create password buffer
@@ -50,7 +50,7 @@ user.encryptPasswordObject = function (password) {
     // Construct the master object from the password buffer
     }).then(function (passwordBuf) {
       data.master = {
-        alg: algos.value('triplesec v3') // 0x22
+        alg: algos.value('triplesec-v3')
       };
 
       // Generate 1024 bit (256 byte) master key

--- a/tests/crypto/user.js
+++ b/tests/crypto/user.js
@@ -19,9 +19,9 @@ describe('Crypto', function () {
   before(function () {
     this.sandbox = sinon.sandbox.create();
   });
-  
+
   describe('users', function () {
-   
+
     describe('#encryptPasswordObject', function () {
       var pwBytes;
       var mkBytes;
@@ -94,10 +94,10 @@ describe('Crypto', function () {
             password: {
               salt: base64url.encode(pwBytes),
               value: base64url.encode(pwCipher.slice(192)),
-              alg: '23'
+              alg: 'scrypt'
             },
             master: {
-              alg: '22',
+              alg: 'triplesec-v3',
               value: base64url.encode(mkCipher)
             }
           });
@@ -120,7 +120,7 @@ describe('Crypto', function () {
     describe('#deriveLoginHmac', function () {
       it('throws error if pw is not a string', function () {
         assert.throws(function () {
-          user.deriveLoginHmac(false); 
+          user.deriveLoginHmac(false);
         }, /password must be a string/);
       });
 
@@ -143,7 +143,7 @@ describe('Crypto', function () {
 
         return user.deriveLoginHmac(pw, salt, token).then(function (hmac) {
           assert.strictEqual(hmac, '-RaUZYPmVh3Hr7ZoTH115ANcPRWwK5BfRYB1A3RIaEKkwt8yGJaWp9ZSI1RssoNqCpOCq7x-O53fEgWqdHdxrg'); // jshint ignore:line
-        }); 
+        });
       });
     });
   });

--- a/types/algos.js
+++ b/types/algos.js
@@ -2,12 +2,12 @@
 var _ = require('lodash');
 
 var algos = {
-  'eddsa': '20', // Value represented in hex
-  'curve25519': '21',
-  'triplesec v3': '22',
-  'scrypt': '23',
-  'nacl easybox': '24',
-  'nacl secretbox': '24',
+  'eddsa': 'eddsa',
+  'curve25519': 'curve25519',
+  'triplesec-v3': 'triplesec-v3',
+  'scrypt': 'scrypt',
+  'nacl easybox': 'nacl-easybox',
+  'nacl secretbox': 'nacl-secretbox',
 };
 
 algos.name = function(b) {


### PR DESCRIPTION
Currently, we're representing algorithm choices inside our data objects
as string hex values. This had a few downsides:

1) We couldn't properly represent hex inside JavaScript since it's not a
supported type, so we ended up with strings like `'0a'` or `'0b'`
instead of `0x0a`.
2) You had to look up in the table which hex values corresponded to
which algorithms.

The utility function for working with algos types is still useful. It
provides a way to share logic for retrieving algo values.

Related arigatomachine/cli#426
