### PR TITLE
Triplesec scrypt expects N to be the exponent

### DIFF
--- a/crypto/kdf.js
+++ b/crypto/kdf.js
@@ -5,7 +5,9 @@ var Promise = require('es6-promise').Promise;
 
 var kdf = exports;
 
-var SCRYPT_N = Math.pow(2, 15); // factor to control cpu/mem suage (2^15)
+// factor to control cpu/mem usage (2^15). triplesec script expects the
+// exponent as its argument.
+var SCRYPT_N = 15;
 var SCRYPT_R = 8; // block size factor
 var SCRYPT_P = 1; // parallelism factor
 var SCRYPT_DKLEN = 224; // generate 224 byte key

--- a/tests/crypto/user.js
+++ b/tests/crypto/user.js
@@ -142,7 +142,7 @@ describe('Crypto', function () {
         var token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dWlkIjoiOWZkNDE5OGMtMWRmNC00YWNhLTkwY2UtZmFlNjI2OGEzZjRlIiwib3duZXJfaWQiOiJBUUhyTnJLY3k4SEdfN0pmQ2RDeThxRE4iLCJpYXQiOjE0NjcwNzYwNTYsImV4cCI6MTQ2NzA3NjM1Nn0.EbRXovJ0a4Uhhi_ASRd3__Y2G_jLlI3iaX8HhCw6fG0'; // jshint ignore:line
 
         return user.deriveLoginHmac(pw, salt, token).then(function (hmac) {
-          assert.strictEqual(hmac, '-RaUZYPmVh3Hr7ZoTH115ANcPRWwK5BfRYB1A3RIaEKkwt8yGJaWp9ZSI1RssoNqCpOCq7x-O53fEgWqdHdxrg'); // jshint ignore:line
+          assert.strictEqual(hmac, 'mfX3n81Ta0itj-J06TYvK0tuaG3v0Jt5zqGk5sWY9iqfqkT5UrFscuSm9zRpWKOdtWcgG8FofBB3qR1QKrWDhg'); // jshint ignore:line
         });
       });
     });


### PR DESCRIPTION
Most scrypt algorithms want you to provide N as the computed value, ie
2^15 = 32768. JS Triplesec expects N to be the exponent value, and does
the calculation itself.

This is fun, as if you pass in 32768, you'll overflow the value of N
back to 1.
