### PR TITLE
Encrypt the master password with the user's passphrase

### DIFF
--- a/tests/crypto/user.js
+++ b/tests/crypto/user.js
@@ -76,13 +76,13 @@ describe('Crypto', function () {
         });
       });
 
-      it('encrypts master key with password slice', function () {
+      it('encrypts master key with password', function () {
         return user.encryptPasswordObject(PLAINTEXT).then(function () {
           sinon.assert.calledOnce(triplesec.encrypt);
           var firstCall = triplesec.encrypt.firstCall;
           assert.deepEqual(firstCall.args[0], {
             data: mkBytes,
-            key: pwCipher.slice(0, 192)
+            key: PLAINTEXT
           });
         });
       });


### PR DESCRIPTION
To allow for future offline access to the master key, encrypt it
directly with the user's passphrase.

Previously, we were using a key derived from the passphrase and a salt.
The salt was stored on the server, meaning we'd need to connect to the
server to get the salt before being able to derive the key.
