### PR TITLE
Introduce CPathExp#contains

### DIFF
--- a/cpath/compare.js
+++ b/cpath/compare.js
@@ -29,15 +29,6 @@
 var cpath = require('./index');
 var definitions = require('./definitions');
 
-var PART_TYPE_REGEX_MAP = {
-  'SLUG': definitions.SLUG_REGEX,
-  'SLUG_WILDCARD': definitions.SLUG_WILDCARD_REGEX,
-  'OR': definitions.OR_EXP_REGEX,
-  'WILDCARD': definitions.WILDCARD_REGEX
-};
-
-var PART_TYPES = Object.keys(PART_TYPE_REGEX_MAP);
-
 var PART_TYPE_SCORE = {
   'SLUG': 4,
   'SLUG_WILDCARD': 3,
@@ -55,8 +46,8 @@ module.exports = function (a, b) {
   var scoreB;
 
   for (var i = 0; i < a.parts.length; ++i) {
-    typeA = getPartType(a.parts[i]);
-    typeB = getPartType(b.parts[i]);
+    typeA = definitions.getPartType(a.parts[i]);
+    typeB = definitions.getPartType(b.parts[i]);
 
     scoreA = PART_TYPE_SCORE[typeA];
     scoreB = PART_TYPE_SCORE[typeB];
@@ -80,15 +71,3 @@ module.exports = function (a, b) {
 
   return 0;
 };
-
-function getPartType (part) {
-  var type;
-  for (var i = 0; i < PART_TYPES.length; ++i) {
-    type = PART_TYPES[i];
-    if (PART_TYPE_REGEX_MAP[type].test(part)) {
-      return type;
-    }
-  }
-
-  throw new Error('Part did not match a PART_TYPE: ' + part);
-}

--- a/cpath/contains.js
+++ b/cpath/contains.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Compares two CPathExp together to determine if A contains B.
+ *
+ * If two segments are an exact match then they are contained.
+ * If segment A is a wildcard then B is contained in A.
+ * If segment A is a slug wildcard then all of B must contain A
+ * If segment A is an OR then the segment is split and B must match *a* segment
+ * of A.
+ * If segment A is an OR and segment B is an OR then all of segment B's parts
+ * must be contained in A.
+ *
+ * @module
+ * @param {CPathExp} a
+ * @param {CPathExp} b
+ * @return {Boolean}
+ */
+var cpath = require('./index');
+var definitions = require('./definitions');
+
+
+function match (a, b) {
+  var typeA = definitions.getPartType(a);
+  var typeB = definitions.getPartType(b);
+
+  // Type Combinations:
+  //  SLUG*SLUG (exact match)
+  //  SLUG*SLUG_WILDCARD (false)
+  //  SLUG_WILDCARD*SLUG (a match b)
+  //  SLUG_WILDCARD*SLUG_WILDCARD (a contained in b)
+  if (typeA === 'SLUG' && typeB === 'SLUG') {
+    return (a === b);
+  }
+  if (typeB === 'SLUG_WILDCARD' && typeA !== 'SLUG_WILDCARD') {
+    return false;
+  }
+
+  // Not possible for A to be a SLUG_WILDCARD without B being a SLUG or
+  // SLUG_WILDCARD since we're dealing with component level strings now and all
+  // wildcards have been ruled out.
+  if (typeA === 'SLUG_WILDCARD') {
+    a = a.slice(0, a.length - 1); // remove the *
+  }
+  if (typeB === 'SLUG_WILDCARD') {
+    b = b.slice(0, b.length - 1); // remove the *
+  }
+
+  return b.indexOf(a) > -1;
+}
+
+function explode (segment) {
+  return segment.slice(1,segment.length - 1).split('|').sort();
+}
+
+function segment (a, b) {
+  // if its an exact match; then we don't have to do anything
+  if (a === b) {
+    return true;
+  }
+
+  var typeA = definitions.getPartType(a);
+  var typeB = definitions.getPartType(b);
+
+  // if a is a wildcard; then we know it matches everything
+  if (typeA === 'WILDCARD') {
+    return true;
+  }
+
+  // if B is a wildcard and A is not then it's not going to match since B is
+  // less specific than A
+  if (typeB === 'WILDCARD') {
+    return false;
+  }
+
+  // It's not possible for an OR to have a wildcard in it; so we don't have to
+  // worry about it at all!
+  var aComponents = (typeA === 'OR') ? explode(a) : [a];
+  var bComponents = (typeB === 'OR') ? explode(b) : [b];
+
+  // All components of B must match one component of A.
+  var matched;
+  for (var i = 0; i < bComponents.length; i++) {
+    matched = false;
+    for (var j = 0; j < aComponents.length; j++) {
+      matched = match(aComponents[j], bComponents[i]);
+      if (matched) {
+        break;
+      }
+    }
+
+    if (!matched) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = function (a, b) {
+  a = (a instanceof cpath.CPathExp) ? a : new cpath.CPathExp(a);
+  b = (b instanceof cpath.CPathExp) ? b : new cpath.CPathExp(b);
+
+  for (var i = 0; i < a.parts.length; ++i) {
+    if (!segment(a.parts[i], b.parts[i])) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/cpath/definitions.js
+++ b/cpath/definitions.js
@@ -40,3 +40,23 @@ definitions.OR_EXP_REGEX = new RegExp('^' + OR_EXP + '$');
 definitions.SLUG_OR_WILDCARD_REGEX =  new RegExp('^' + SLUG_OR_WILDCARD + '$');
 definitions.CPATHEXP_REGEX = new RegExp(CPATHEXP_REGEX_STR);
 definitions.CPATH_REGEX = new RegExp(CPATH_REGEX_STR);
+
+var PART_TYPE_REGEX_MAP = definitions.PART_TYPE_REGEX_MAP = {
+  'SLUG': definitions.SLUG_REGEX,
+  'SLUG_WILDCARD': definitions.SLUG_WILDCARD_REGEX,
+  'OR': definitions.OR_EXP_REGEX,
+  'WILDCARD': definitions.WILDCARD_REGEX
+};
+var PART_TYPES = Object.keys(PART_TYPE_REGEX_MAP);
+
+definitions.getPartType = function (part) {
+  var type;
+  for (var i = 0; i < PART_TYPES.length; ++i) {
+    type = PART_TYPES[i];
+    if (PART_TYPE_REGEX_MAP[type].test(part)) {
+      return type;
+    }
+  }
+
+  throw new Error('Part did not match a PART_TYPE: ' + part);
+};

--- a/cpath/index.js
+++ b/cpath/index.js
@@ -50,6 +50,7 @@ var util = require('util');
 var normalize = require('./normalize');
 var regex = require('./regex');
 var compare = require('./compare');
+var contains = require('./contains');
 var definitions = require('./definitions');
 
 cpath.parseExp = function (str) {
@@ -136,6 +137,17 @@ CPathExp.prototype.toString = function () {
  */
 CPathExp.prototype.compare = function (str) {
   return this.regex.test(str);
+};
+
+/**
+ * Returns true or false depending on whether or not the given pathexp
+ * is contained within the path of this cpathexp.
+ *
+ * @param {CPathExp} obj
+ * @returns {Boolean}
+ */
+CPathExp.prototype.contains = function (obj) {
+  return contains(this, obj);
 };
 
 function CPath (str) {

--- a/tests/cpath.js
+++ b/tests/cpath.js
@@ -266,5 +266,37 @@ describe('cpath', function () {
         assert.strictEqual(obj.compare('/org/proj/ci/api/ci-1/1'), false);
       });
     });
+
+    describe('#contains', function () {
+      it('instance is wildcard', function () {
+        var obj = cpath.parseExp('/org/proj/dev-1/api/*/*');
+
+        assert.ok(obj.contains('/org/proj/dev-1/api/*/1'));
+        assert.ok(!obj.contains('/org/proj/dev-1/[api|www]/*/*'));
+      });
+
+      it('env is wildcard', function () {
+        var obj = cpath.parseExp('/org/proj/*/api/*/*');
+
+        assert.ok(obj.contains('/org/proj/prod/api/[ian-*|jeff-*]/1'));
+        assert.ok(obj.contains('/org/proj/dev-*/api/ian/*'));
+        assert.ok(!obj.contains('/org/proj/*/*/*/*'));
+        assert.ok(!obj.contains('/org/proj/prod/www/*/*'));
+        assert.ok(!obj.contains('/org/proj/prod/[api|www]/*/*'));
+        assert.ok(!obj.contains('/abc/proj/dfsf/sdfsf/*/*'));
+      });
+
+      it('a contains OR and B contains OR', function () {
+        var obj = cpath.parseExp('/org/proj/*/[api|www|worker-*]/*/*');
+        
+        assert.ok(obj.contains('/org/proj/*/api/*/*'));
+        assert.ok(obj.contains('/org/proj/*/www/*/*'));
+        assert.ok(obj.contains('/org/proj/*/worker-1/*/*'));
+        assert.ok(obj.contains('/org/proj/*/[api|www]/*/*'));
+        assert.ok(obj.contains('/org/proj/*/worker-*/*/*'));
+        assert.ok(!obj.contains('/org/proj/*/worker/*/*'));
+        assert.ok(!obj.contains('/org/proj/*/*/*/*'));
+      });
+    });
   });
 });


### PR DESCRIPTION
To determine whether or not a credential belongs to a keyring we need to
check if the keyrings cpathexp contains the credential cpathexp.

This new method trues true/false depending on whether the given CPathExp
is conatined within the target pathexp.

Related arigatomachine/cli#465
