### PR TITLE
Do not ignore missing schema

### DIFF
--- a/validate/index.js
+++ b/validate/index.js
@@ -102,11 +102,7 @@ Validate.prototype._requireSchema = function (schemaPath) {
   }
 
   var self = this;
-  try {
-    self.schemas[schemaPath] = require(schemaPath);
-  } catch(ignoreErr) {
-    console.warn('could not read schema', ignoreErr);
-  }
+  self.schemas[schemaPath] = require(schemaPath);
   return this.schemas[schemaPath];
 };
 


### PR DESCRIPTION
If a schema is missing then it's a developer error! We should be as
noisy as possible to ensure that these bugs get fixed.